### PR TITLE
Refactor flow prompt tracking

### DIFF
--- a/__tests__/flowPromptTracker.test.js
+++ b/__tests__/flowPromptTracker.test.js
@@ -1,0 +1,43 @@
+const { createFlowPromptTracker } = require('../src/app/flowPromptTracker');
+
+describe('createFlowPromptTracker', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('retorna undefined quando nada foi lembrado', () => {
+        const tracker = createFlowPromptTracker();
+        tracker.remember('chat');
+        expect(tracker.recentFlowKey('chat')).toBeUndefined();
+    });
+
+    it('retorna a chave do fluxo quando dentro da janela configurada', () => {
+        const tracker = createFlowPromptTracker({ windowMs: 1000 });
+        tracker.remember('chat-1', 'menu');
+        expect(tracker.recentFlowKey('chat-1')).toBe('menu');
+        jest.advanceTimersByTime(1500);
+        expect(tracker.recentFlowKey('chat-1')).toBeUndefined();
+    });
+
+    it('atualiza o timestamp ao lembrar sem fornecer a chave', () => {
+        const tracker = createFlowPromptTracker({ windowMs: 5000 });
+        tracker.remember('chat-2', 'catalog');
+        jest.advanceTimersByTime(4000);
+        tracker.remember('chat-2');
+        jest.advanceTimersByTime(4000);
+        expect(tracker.recentFlowKey('chat-2')).toBe('catalog');
+    });
+
+    it('remove registros corretamente', () => {
+        const tracker = createFlowPromptTracker();
+        tracker.remember('chat-3', 'menu');
+        expect(tracker.recentFlowKey('chat-3')).toBe('menu');
+        tracker.clear('chat-3');
+        expect(tracker.recentFlowKey('chat-3')).toBeUndefined();
+    });
+});

--- a/src/app/flowPromptTracker.js
+++ b/src/app/flowPromptTracker.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * @typedef {Object} FlowPromptEntry
+ * @property {number} at
+ * @property {string} flow
+ */
+
+/**
+ * @typedef {Object} FlowPromptTracker
+ * @property {(chatId: string, flowKey?: string) => void} remember
+ * @property {(chatId: string) => void} clear
+ * @property {(chatId: string) => FlowPromptEntry | undefined} get
+ * @property {(chatId: string) => boolean} isRecent
+ * @property {(chatId: string) => string | undefined} recentFlowKey
+ */
+
+const DEFAULT_FLOW_PROMPT_WINDOW_MS = 2 * 60 * 1000;
+
+/**
+ * Implementa um pequeno *State Tracker* (variação do pattern *State*) para
+ * controlar prompts de fluxos por chat. A API é pensada para uso imutável,
+ * retornando um objeto congelado que expõe apenas operações de alto nível,
+ * evitando vazamento da estrutura interna.
+ *
+ * @param {{ windowMs?: number }} [options]
+ * @returns {FlowPromptTracker}
+ */
+function createFlowPromptTracker({ windowMs = DEFAULT_FLOW_PROMPT_WINDOW_MS } = {}) {
+  /** @type {Map<string, FlowPromptEntry>} */
+  const entries = new Map();
+
+  /**
+   * Atualiza (ou cria) um registro para o chat.
+   *
+   * @param {string} chatId
+   * @param {string} [flowKey]
+   * @returns {void}
+   */
+  const remember = (chatId, flowKey) => {
+    if (!chatId) return;
+    const previous = entries.get(chatId);
+    const resolvedKey = flowKey ?? previous?.flow;
+    if (!resolvedKey) return;
+    entries.set(chatId, { at: Date.now(), flow: resolvedKey });
+  };
+
+  /**
+   * Remove o registro do chat.
+   *
+   * @param {string} chatId
+   * @returns {void}
+   */
+  const clear = (chatId) => {
+    if (!chatId) return;
+    entries.delete(chatId);
+  };
+
+  /**
+   * Recupera o registro completo (principalmente para testes ou logging).
+   *
+   * @param {string} chatId
+   * @returns {FlowPromptEntry | undefined}
+   */
+  const get = (chatId) => {
+    if (!chatId) return undefined;
+    return entries.get(chatId);
+  };
+
+  /**
+   * Indica se o prompt armazenado ainda é considerado recente.
+   *
+   * @param {string} chatId
+   * @returns {boolean}
+   */
+  const isRecent = (chatId) => {
+    const entry = get(chatId);
+    if (!entry) return false;
+    return Date.now() - entry.at <= windowMs;
+  };
+
+  /**
+   * Retorna a chave do fluxo se o prompt for recente.
+   *
+   * @param {string} chatId
+   * @returns {string | undefined}
+   */
+  const recentFlowKey = (chatId) => {
+    if (!isRecent(chatId)) return undefined;
+    return get(chatId)?.flow;
+  };
+
+  return Object.freeze({ remember, clear, get, isRecent, recentFlowKey });
+}
+
+module.exports = {
+  createFlowPromptTracker,
+  DEFAULT_FLOW_PROMPT_WINDOW_MS,
+};


### PR DESCRIPTION
## Summary
- extract flow prompt tracking into a dedicated tracker with explicit state handling
- fix prompt formatting so option lists do not start with a blank line
- cover the tracker with focused unit tests and reuse it during flow restarts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d893191bac83309635be8c18a062fa