### PR TITLE
feat: register flows dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ npm test
 
 ## Estrutura
 - `main.js`: inicialização do cliente e handlers de mensagens.
+- `src/flows/index.js`: aplica o padrão Registry; basta criar um novo arquivo `.js` em `src/flows/` que o fluxo será descoberto automaticamente.
 - `src/validation/answers.js`: validação de opções e matcher.
 - `src/validation/flows.js`: validação e simulação de fluxos de decisão.
 - `__tests__/`: testes unitários e mocks.

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -31,7 +31,19 @@ describe('Fluxos de menu (texto via FlowEngine)', () => {
     jest.resetModules();
     process.env.MENU_FLOW = '1';
     const { createApp } = require('../src/app/appFactory');
-    const { flow: MenuFlow } = require('../src/flows/menu');
+    const flows = require('../src/flows');
+    /**
+     * @template T
+     * @param {{ flow?: T } | T} entry
+     * @returns {T}
+     */
+    const resolveFlow = (entry) => {
+      if (entry && typeof entry === 'object' && 'flow' in entry && entry.flow) {
+        return /** @type {T} */ (entry.flow);
+      }
+      return /** @type {T} */ (entry);
+    };
+    const MenuFlow = resolveFlow(flows.menu);
 
     app = createApp({
       buildHandlers: ({ client, rate, flowEngine }) => {

--- a/main.js
+++ b/main.js
@@ -1,8 +1,20 @@
 const fs = require('fs/promises');
 const path = require('path');
 const { TEXT } = require('./src/config/messages');
-const { flow: CatalogFlow } = require('./src/flows/catalog');
-const { flow: MenuFlow } = require('./src/flows/menu');
+const flows = require('./src/flows');
+/**
+ * @template T
+ * @param {{ flow?: T } | T} entry
+ * @returns {T}
+ */
+function resolveFlow(entry) {
+    if (entry && typeof entry === 'object' && 'flow' in entry && entry.flow) {
+        return /** @type {T} */ (entry.flow);
+    }
+    return /** @type {T} */ (entry);
+}
+const CatalogFlow = resolveFlow(flows.catalog);
+const MenuFlow = resolveFlow(flows.menu);
 const { createApp } = require('./src/app/appFactory');
 const { createCommandRegistry } = require('./src/app/commandRegistry');
 const {

--- a/src/flows/index.js
+++ b/src/flows/index.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * @typedef {{ id: string, text: string, next?: string, aliases?: string[], correct?: boolean }} FlowNodeOption
+ */
+/**
+ * @typedef {{ prompt?: string, terminal?: boolean, options?: FlowNodeOption[] }} FlowNode
+ */
+/**
+ * @typedef {{ start: string, nodes: Record<string, FlowNode> }} FlowDefinition
+ */
+/** @typedef {{ flow: FlowDefinition }} FlowModule */
+
+/**
+ * Normaliza o módulo carregado para sempre expor `{ flow }`.
+ * @param {unknown} mod
+ * @returns {FlowModule}
+ */
+function normalizeFlowModule(mod) {
+  if (mod && typeof mod === 'object') {
+    const maybeModule = /** @type {{ flow?: FlowDefinition, default?: unknown }} */ (mod);
+    if (maybeModule.flow) {
+      return /** @type {FlowModule} */ (maybeModule);
+    }
+    if (maybeModule.default) {
+      return normalizeFlowModule(maybeModule.default);
+    }
+  }
+  return { flow: /** @type {FlowDefinition} */ (mod) };
+}
+
+/**
+ * Carrega todos os fluxos presentes neste diretório seguindo o padrão Registry.
+ * @returns {Record<string, FlowModule>}
+ */
+function loadFlowModules() {
+  return fs
+    .readdirSync(__dirname)
+    .filter(file => file.endsWith('.js') && file !== 'index.js')
+    .sort()
+    .reduce((acc, file) => {
+      const key = path.basename(file, '.js');
+      const required = require(path.join(__dirname, file));
+      acc[key] = normalizeFlowModule(required);
+      return acc;
+    }, /** @type {Record<string, FlowModule>} */ ({}));
+}
+
+const registry = loadFlowModules();
+
+/**
+ * Novos fluxos são descobertos automaticamente: basta adicionar um novo arquivo
+ * `.js` neste diretório e ele será registrado ao iniciar a aplicação.
+ */
+module.exports = registry;


### PR DESCRIPTION
## Summary
- add a registry index that auto-discovers flow modules in `src/flows`
- update main entry point and tests to resolve flows through the registry with safe fallbacks
- document the registry workflow in the README for future flow additions

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d896da4d7c83308b24f35a92acea62