### PR TITLE
Add dotenv configuration support

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const fs = require('fs/promises');
 const path = require('path');
 const { TEXT } = require('./src/config/messages');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^16.4.5",
         "qrcode-terminal": "^0.12.0",
         "whatsapp-web.js": "^1.34.1"
       },
@@ -1893,6 +1894,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexer2": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Bruno M Noronha",
   "license": "ISC",
   "dependencies": {
+    "dotenv": "^16.4.5",
     "qrcode-terminal": "^0.12.0",
     "whatsapp-web.js": "^1.34.1"
   },


### PR DESCRIPTION
## Summary
- add dotenv as a runtime dependency and configure it at startup
- initialize dotenv in the main entrypoint so environment variables load before use

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d898cfd1708330b0d0d729353a700c