### PR TITLE
Atualiza placeholders de configuração no .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,12 @@ MENU_FLOW=1
 OWNER_ID=
 ALLOW_SELF_ADMIN=0
 
-# Rate limiting
-RATE_LIMIT_PER_CHAT_MS=1500
-RATE_LIMIT_GLOBAL_MAX=10
-RATE_LIMIT_GLOBAL_INTERVAL_MS=1000
+# Limites de uso (rate limiting)
+RATE_PER_CHAT_COOLDOWN_MS=1500
+THROTTLE_GLOBAL_MAX=10
+THROTTLE_GLOBAL_INTERVAL_MS=1000
 
-# Configuração de timeout de fluxos
+# Configuração de timeout de fluxos (já suportados)
 FLOW_PROMPT_WINDOW_MS=120000
 FLOW_TTL_SECONDS=1800
 
@@ -23,3 +23,7 @@ FLOW_REDIS_PREFIX=wwebjs:flow:
 
 # Ambiente
 NODE_ENV=development
+
+# Puppeteer/Chrome
+CHROME_PATH= # Caminho personalizado para o executável do Chrome/Chromium
+PUPPETEER_SINGLE_PROCESS=0 # Defina como 1 para executar o Puppeteer em single-process


### PR DESCRIPTION
## Summary
- atualiza as variáveis de rate limiting para os novos nomes suportados
- adiciona placeholders comentados para CHROME_PATH e PUPPETEER_SINGLE_PROCESS
- revisa blocos do .env.example para manter descrições consistentes

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8997cb4cc833096edcb2319390ca5