### PR TITLE
Handle incoming messages only on creation event

### DIFF
--- a/__tests__/admin.test.js
+++ b/__tests__/admin.test.js
@@ -30,8 +30,9 @@ describe('Admin commands (!shutdown) with self-testing', () => {
   });
 
   test('!shutdown enviado por mim mesmo executa gracefulShutdown sem loop', async () => {
+    /** @type {{ from: string; fromMe: boolean; body: string }} */
     const msg = { from: MY_ID, fromMe: true, body: '!shutdown' };
-    app.client.emit('message', msg);
+    app.client.emit('message_create', msg);
     await new Promise(r => setImmediate(r));
     expect(app.client.destroyed).toBe(true);
   });
@@ -44,8 +45,9 @@ describe('Admin commands (!shutdown) with self-testing', () => {
 
     expect(app.client.initialized).toBeFalsy(); // em NODE_ENV=test, start não chama initialize
 
+    /** @type {{ from: string; fromMe: boolean; body: string }} */
     const msg = { from: MY_ID, fromMe: true, body: '!restart' };
-    app.client.emit('message', msg);
+    app.client.emit('message_create', msg);
     await new Promise(r => setImmediate(r));
 
     expect(app.client.destroyed).toBe(true);

--- a/__tests__/flow-restart.test.js
+++ b/__tests__/flow-restart.test.js
@@ -28,8 +28,13 @@ describe('Fluxo recente é reiniciado com o mesmo tipo', () => {
   let app;
   const chatId = '5511987654321@c.us';
 
+  /**
+   * @param {string} body
+   * @param {Record<string, unknown>} [extra]
+   * @returns {Promise<void>}
+   */
   const emitMessage = async (body, extra = {}) => {
-    app.client.emit('message', { from: chatId, to: 'bot@c.us', body, fromMe: false, ...extra });
+    app.client.emit('message_create', { from: chatId, to: 'bot@c.us', body, fromMe: false, ...extra });
     await new Promise(r => setImmediate(r));
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1897,9 +1897,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/src/app/appFactory.js
+++ b/src/app/appFactory.js
@@ -97,7 +97,6 @@ function registerHandlers(client, { handleIncoming, onQR, onReady, onAuthFail, o
   if (onAuthFail) client.on('auth_failure', onAuthFail);
   if (onDisconnected) client.on('disconnected', onDisconnected);
   if (handleIncoming) {
-    client.on('message', handleIncoming);
     client.on('message_create', handleIncoming);
   }
 }


### PR DESCRIPTION
## Summary
- remove the `message` listener registration so incoming handling uses only `message_create`
- update admin and flow restart tests to emit `message_create` events and add type hints to fixtures
- refresh the lockfile after installing required dependencies for tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8a39f50ec8330badb2826036a50cb