### PR TITLE
Ensure admin commands handle notification failures gracefully

### DIFF
--- a/__mocks__/dotenv.js
+++ b/__mocks__/dotenv.js
@@ -1,0 +1,1 @@
+module.exports = { config: jest.fn() };

--- a/__tests__/admin.test.js
+++ b/__tests__/admin.test.js
@@ -9,8 +9,61 @@ jest.mock('whatsapp-web.js', () => {
   return { Client, LocalAuth };
 });
 jest.mock('qrcode-terminal', () => ({ generate: jest.fn() }));
+jest.mock('dotenv');
 
 const MY_ID = '5561985307168@c.us';
+const { createCommandRegistry } = require('../src/app/commandRegistry');
+
+/** @typedef {Parameters<typeof createCommandRegistry>[0]} CommandRegistryDeps */
+/** @typedef {ReturnType<typeof createCommandRegistry>} CommandRegistry */
+
+/**
+ * @param {Partial<CommandRegistryDeps>} overrides
+ * @returns {{ registry: CommandRegistry, mocks: { sendSafe: jest.Mock, gracefulShutdown: jest.Mock, gracefulRestart: jest.Mock } }}
+ */
+function buildAdminRegistry(overrides = {}) {
+  const sendSafeMock = overrides.sendSafe ? /** @type {jest.Mock} */ (overrides.sendSafe) : jest.fn().mockResolvedValue(undefined);
+  const gracefulShutdownMock = overrides.gracefulShutdown ? /** @type {jest.Mock} */ (overrides.gracefulShutdown) : jest.fn().mockResolvedValue(undefined);
+  const gracefulRestartMock = overrides.gracefulRestart ? /** @type {jest.Mock} */ (overrides.gracefulRestart) : jest.fn().mockResolvedValue(undefined);
+
+  /** @type {CommandRegistryDeps} */
+  const deps = {
+    sendSafe: sendSafeMock,
+    sendFlowPrompt: jest.fn().mockResolvedValue(undefined),
+    clearFlowPrompt: jest.fn(),
+    flowEngine: {
+      start: jest.fn().mockResolvedValue({ ok: false }),
+    },
+    menuFlow: {},
+    catalogFlow: {},
+    gracefulShutdown: gracefulShutdownMock,
+    gracefulRestart: gracefulRestartMock,
+    welcomeText: 'welcome',
+    flowUnavailableText: 'unavailable',
+    shutdownNotice: 'shutdown',
+    restartNotice: 'restart',
+    shouldExitOnShutdown: false,
+    ...overrides,
+  };
+
+  return { registry: createCommandRegistry(deps), mocks: { sendSafe: sendSafeMock, gracefulShutdown: gracefulShutdownMock, gracefulRestart: gracefulRestartMock } };
+}
+
+/**
+ * @param {Partial<{ isOwner: boolean; fromSelf: boolean }>} overrides
+ * @returns {{ isOwner: boolean; fromSelf: boolean }}
+ */
+function createOwnerContext(overrides = {}) {
+  return { isOwner: true, fromSelf: false, ...overrides };
+}
+
+/**
+ * @param {string} body
+ * @returns {{ from: string; body: string; fromMe?: boolean }}
+ */
+function createIncomingMessage(body) {
+  return { from: '123@c.us', body };
+}
 
 describe('Admin commands (!shutdown) with self-testing', () => {
   let app;
@@ -52,5 +105,44 @@ describe('Admin commands (!shutdown) with self-testing', () => {
 
     expect(app.client.destroyed).toBe(true);
     expect(app.client.initialized).toBe(true);
+  });
+});
+
+describe('Command registry admin notifications', () => {
+  /** @type {jest.SpyInstance} */
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('gracefulShutdown executa mesmo que o aviso falhe', async () => {
+    const failure = new Error('network down');
+    const { registry, mocks } = buildAdminRegistry({ sendSafe: jest.fn().mockRejectedValue(failure) });
+
+    const handled = await registry.run('!shutdown', createIncomingMessage('!shutdown'), createOwnerContext());
+
+    expect(handled).toBe(true);
+    expect(mocks.sendSafe).toHaveBeenCalledWith('123@c.us', 'shutdown');
+    expect(mocks.gracefulShutdown).toHaveBeenCalledWith({ exit: false });
+    expect(mocks.gracefulRestart).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test('gracefulRestart executa mesmo que o aviso falhe', async () => {
+    const failure = new Error('offline');
+    const { registry, mocks } = buildAdminRegistry({ sendSafe: jest.fn().mockRejectedValue(failure) });
+
+    const handled = await registry.run('!restart', createIncomingMessage('!restart'), createOwnerContext());
+
+    expect(handled).toBe(true);
+    expect(mocks.sendSafe).toHaveBeenCalledWith('123@c.us', 'restart');
+    expect(mocks.gracefulRestart).toHaveBeenCalledTimes(1);
+    expect(mocks.gracefulShutdown).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,2 @@
 process.env.NODE_ENV = 'test';
+jest.mock('dotenv');

--- a/src/app/commandRegistry.js
+++ b/src/app/commandRegistry.js
@@ -74,19 +74,35 @@ function createCommandRegistry(deps) {
 
   register(['!shutdown'], async (message, context) => {
     if (!context.isOwner) return false;
-    if (!context.fromSelf) {
-      await sendSafe(message.from, shutdownNotice);
+
+    try {
+      if (!context.fromSelf) {
+        await sendSafe(message.from, shutdownNotice);
+      }
+    } catch (/** @type {unknown} */ error) {
+      const parsedError = error instanceof Error ? error : new Error(String(error));
+      console.warn('[commandRegistry] Falha ao enviar aviso de desligamento:', parsedError);
+    } finally {
+      await gracefulShutdown({ exit: shouldExitOnShutdown });
     }
-    await gracefulShutdown({ exit: shouldExitOnShutdown });
+
     return true;
   });
 
   register(['!restart'], async (message, context) => {
     if (!context.isOwner) return false;
-    if (!context.fromSelf) {
-      await sendSafe(message.from, restartNotice);
+
+    try {
+      if (!context.fromSelf) {
+        await sendSafe(message.from, restartNotice);
+      }
+    } catch (/** @type {unknown} */ error) {
+      const parsedError = error instanceof Error ? error : new Error(String(error));
+      console.warn('[commandRegistry] Falha ao enviar aviso de reinício:', parsedError);
+    } finally {
+      await gracefulRestart();
     }
-    await gracefulRestart();
+
     return true;
   });
 


### PR DESCRIPTION
## Summary
- wrap shutdown and restart command notifications in try/catch blocks that always trigger graceful operations
- log warning when notification delivery fails and add a shared dotenv mock for tests
- extend admin command tests with helpers that mock sendSafe failures and verify graceful shutdown/restart execution

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8a902b5a88330b8623c2a86764643