### PR TITLE
Handle missing flow node in engine

### DIFF
--- a/__tests__/flow-engine.test.js
+++ b/__tests__/flow-engine.test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const { FlowEngine } = require('../src/flow-runtime/engine');
+
+/**
+ * @typedef {import('../src/flow-runtime/engine')} FlowEngineModule
+ */
+
+/**
+ * @typedef {FlowEngineModule['FlowEngine']} FlowEngineInstance
+ */
+
+/**
+ * @typedef {{ start: string, nodes: Record<string, any> }} FlowDefinition
+ */
+
+/**
+ * @typedef {{ flow: FlowDefinition, current: string }} FlowState
+ */
+
+/**
+ * @typedef {{
+ *   get(chatId: string): Promise<FlowState | null>,
+ *   set(chatId: string, value: FlowState): Promise<void>,
+ *   clear(chatId: string): Promise<void>,
+ *   has(chatId: string): Promise<boolean>
+ * }} FlowStateStore
+ */
+
+/**
+ * Armazena estados em memória para testes.
+ *
+ * @implements {FlowStateStore}
+ */
+class TestStore {
+  constructor() {
+    /** @type {Map<string, FlowState>} */
+    this.state = new Map();
+    /** @type {number} */
+    this.clearCalls = 0;
+  }
+
+  /**
+   * @param {string} chatId
+   * @returns {Promise<FlowState | null>}
+   */
+  async get(chatId) {
+    return this.state.get(chatId) ?? null;
+  }
+
+  /**
+   * @param {string} chatId
+   * @param {FlowState} value
+   * @returns {Promise<void>}
+   */
+  async set(chatId, value) {
+    this.state.set(chatId, value);
+  }
+
+  /**
+   * @param {string} chatId
+   * @returns {Promise<void>}
+   */
+  async clear(chatId) {
+    this.clearCalls += 1;
+    this.state.delete(chatId);
+  }
+
+  /**
+   * @param {string} chatId
+   * @returns {Promise<boolean>}
+   */
+  async has(chatId) {
+    return this.state.has(chatId);
+  }
+}
+
+describe('FlowEngine - missing node recovery', () => {
+  /** @type {TestStore} */
+  let store;
+  /** @type {FlowEngineInstance} */
+  let engine;
+  /** @type {FlowDefinition} */
+  let flow;
+
+  beforeEach(() => {
+    store = new TestStore();
+    engine = new FlowEngine(store);
+    flow = {
+      start: 'start',
+      nodes: {
+        start: {
+          prompt: 'Olá',
+          options: [
+            {
+              text: 'Ir',
+              next: 'missing-node',
+            },
+          ],
+        },
+      },
+    };
+  });
+
+  it('limpa o estado e retorna erro quando o nó atual está ausente', async () => {
+    const chatId = 'chat-123';
+    await store.set(chatId, { flow, current: 'missing-node' });
+
+    const result = await engine.advance(chatId, 'qualquer coisa');
+
+    expect(result).toEqual({ ok: false, error: 'no_node', nodeId: 'missing-node' });
+    expect(await store.has(chatId)).toBe(false);
+    expect(store.clearCalls).toBe(1);
+  });
+});

--- a/src/flow-runtime/engine.js
+++ b/src/flow-runtime/engine.js
@@ -4,13 +4,59 @@ const { validateOptionFlow } = require('../validation/flows');
 const { buildOptionMatcher } = require('../validation/answers');
 const { createStore } = require('./stateStore');
 
+/**
+ * @typedef {Object} FlowOption
+ * @property {string} text
+ * @property {string} [next]
+ * @property {string[]} [aliases]
+ * @property {boolean} [correct]
+ */
+
+/**
+ * @typedef {Object} FlowNode
+ * @property {string} [id]
+ * @property {string} [prompt]
+ * @property {boolean} [terminal]
+ * @property {FlowOption[]} [options]
+ */
+
+/**
+ * @typedef {Object} FlowDefinition
+ * @property {string} start
+ * @property {Record<string, FlowNode>} nodes
+ */
+
+/**
+ * @typedef {Object} FlowState
+ * @property {FlowDefinition} flow
+ * @property {string} current
+ */
+
+/**
+ * @typedef {{
+ *   get(chatId: string): Promise<FlowState | null>,
+ *   set(chatId: string, value: FlowState): Promise<void>,
+ *   clear(chatId: string): Promise<void>,
+ *   has(chatId: string): Promise<boolean>
+ * }} FlowStateStore
+ */
+
 // Engine simples para conduzir fluxos por chatId
 class FlowEngine {
+  /**
+   * @param {FlowStateStore} [store]
+   */
   constructor(store = createStore()) {
+    /** @type {FlowStateStore} */
     this.store = store;
   }
 
   // Inicia um fluxo para o chatId, validando-o
+  /**
+   * @param {string} chatId
+   * @param {FlowDefinition} flow
+   * @returns {Promise<{ ok: true, node: FlowNode } | { ok: false, error: string, details?: string[] }>}
+   */
   async start(chatId, flow) {
     const res = validateOptionFlow(flow, undefined, {});
     if (!res.ok) {
@@ -20,27 +66,57 @@ class FlowEngine {
     return { ok: true, node: flow.nodes[flow.start] };
   }
 
+  /**
+   * @param {string} chatId
+   * @returns {Promise<FlowState | null>}
+   */
   async getState(chatId) {
     return this.store.get(chatId);
   }
 
+  /**
+   * @param {string} chatId
+   * @returns {Promise<boolean>}
+   */
   async isActive(chatId) {
     return this.store.has(chatId);
   }
 
+  /**
+   * @param {string} chatId
+   * @returns {Promise<void>}
+   */
   async cancel(chatId) {
     await this.store.clear(chatId);
   }
 
   // Avança o fluxo com uma entrada de usuário; retorna o próximo prompt (ou terminal)
+  /**
+   * @param {string} chatId
+   * @param {string} inputRaw
+   * @returns {Promise<
+   *   | { ok: false, error: string, expected?: string[], nodeId?: string }
+   *   | {
+   *       ok: true,
+   *       terminal: boolean,
+   *       prompt: string | undefined,
+   *       options?: string[]
+   *     }
+   * >}
+   */
   async advance(chatId, inputRaw) {
     const st = await this.store.get(chatId);
     if (!st) return { ok: false, error: 'Sem fluxo ativo' };
     const { flow, current } = st;
     const node = flow.nodes[current];
-    if (!node || !Array.isArray(node.options) || node.options.length === 0) {
+    if (!node) {
       await this.store.clear(chatId);
-      return { ok: true, terminal: true, prompt: node?.prompt };
+      return { ok: false, error: 'no_node', nodeId: current };
+    }
+
+    if (!Array.isArray(node.options) || node.options.length === 0) {
+      await this.store.clear(chatId);
+      return { ok: true, terminal: true, prompt: node.prompt };
     }
 
     const matcher = buildOptionMatcher(node.options);


### PR DESCRIPTION
## Summary
- add flow engine typedefs and ensure missing nodes return a structured error before treating no-option terminals
- keep terminal completion logic for nodes without options intact while reporting missing-node details
- cover missing node scenarios with a dedicated FlowEngine unit test using a typed in-memory store stub

## Testing
- npx jest --runInBand __tests__/flow-engine.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8d47e3bc48330afdd1b6fc3e9ba97