### PR TITLE
Handle missing flow nodes explicitly

### DIFF
--- a/__tests__/flow-engine.test.js
+++ b/__tests__/flow-engine.test.js
@@ -112,4 +112,25 @@ describe('FlowEngine - missing node recovery', () => {
     expect(await store.has(chatId)).toBe(false);
     expect(store.clearCalls).toBe(1);
   });
+
+  it('encerra o fluxo para nós válidos sem opções', async () => {
+    const chatId = 'chat-456';
+    /** @type {FlowDefinition} */
+    const terminalFlow = {
+      start: 'start',
+      nodes: {
+        start: {
+          prompt: 'Fim',
+        },
+      },
+    };
+
+    await store.set(chatId, { flow: terminalFlow, current: 'start' });
+
+    const result = await engine.advance(chatId, 'irrelevante');
+
+    expect(result).toEqual({ ok: true, terminal: true, prompt: 'Fim' });
+    expect(await store.has(chatId)).toBe(false);
+    expect(store.clearCalls).toBe(1);
+  });
 });

--- a/src/flow-runtime/engine.js
+++ b/src/flow-runtime/engine.js
@@ -114,7 +114,8 @@ class FlowEngine {
       return { ok: false, error: 'no_node', nodeId: current };
     }
 
-    if (!Array.isArray(node.options) || node.options.length === 0) {
+    const hasOptions = Array.isArray(node.options) && node.options.length > 0;
+    if (!hasOptions) {
       await this.store.clear(chatId);
       return { ok: true, terminal: true, prompt: node.prompt };
     }


### PR DESCRIPTION
## Summary
- clear the flow state and surface a dedicated `no_node` error when the current node is missing
- keep terminal handling restricted to valid nodes that lack options
- cover missing-node and optionless-node flows with targeted unit tests

## Testing
- npm test -- flow-engine

------
https://chatgpt.com/codex/tasks/task_e_68d8d7f7ffb08330883e7251db988bc4