### PR TITLE
chore: configure eslint and prettier

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+coverage

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,99 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2021: true,
+  },
+  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
+  plugins: ['prettier'],
+  rules: {
+    'prettier/prettier': 'warn',
+  },
+  overrides: [
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
+      },
+      plugins: ['@typescript-eslint'],
+      extends: [
+        'plugin:@typescript-eslint/recommended',
+        'plugin:@typescript-eslint/recommended-requiring-type-checking',
+      ],
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': [
+          'warn',
+          {
+            allowExpressions: true,
+            allowTypedFunctionExpressions: true,
+          },
+        ],
+        '@typescript-eslint/explicit-module-boundary-types': 'warn',
+        '@typescript-eslint/no-unused-vars': [
+          'warn',
+          {
+            argsIgnorePattern: '^_',
+            varsIgnorePattern: '^_',
+          },
+        ],
+        '@typescript-eslint/consistent-type-imports': [
+          'warn',
+          {
+            prefer: 'type-imports',
+            fixStyle: 'inline-type-imports',
+          },
+        ],
+        '@typescript-eslint/consistent-type-definitions': ['warn', 'interface'],
+        '@typescript-eslint/no-misused-promises': 'warn',
+        '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
+        '@typescript-eslint/no-empty-object-type': 'warn',
+        '@typescript-eslint/no-unsafe-member-access': 'warn',
+        '@typescript-eslint/require-await': 'warn',
+      },
+    },
+    {
+      files: ['**/__tests__/**/*.{ts,tsx,js,jsx}', '**/*.spec.{ts,tsx,js,jsx}', '**/*.test.{ts,tsx,js,jsx}'],
+      env: {
+        jest: true,
+        node: true,
+      },
+      rules: {
+        '@typescript-eslint/no-unsafe-assignment': 'off',
+        '@typescript-eslint/no-unsafe-call': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
+        '@typescript-eslint/require-await': 'off',
+      },
+    },
+    {
+      files: ['**/__mocks__/**/*.{js,ts}'],
+      env: {
+        jest: true,
+        node: true,
+      },
+    },
+    {
+      files: ['jest.setup.js', 'jest.afterEnv.js'],
+      env: {
+        jest: true,
+        node: true,
+      },
+      rules: {
+        'no-empty': 'off',
+      },
+    },
+    {
+      files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
+      parserOptions: {
+        sourceType: 'module',
+      },
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off',
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/explicit-module-boundary-types': 'off',
+      },
+    },
+  ],
+  ignorePatterns: ['dist', 'node_modules', 'coverage'],
+};

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "printWidth": 100,
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "tsc -p tsconfig.json",
     "prestart": "npm run build",
     "start": "node dist/main.js",
+    "lint": "eslint . --ext .ts,.js",
+    "format": "prettier --write .",
     "test": "jest --runInBand",
     "test:watch": "jest --watchAll",
     "test:answers": "jest --runInBand -t \"(answers|opções|options)\"",
@@ -14,7 +16,7 @@
     "test:flows": "jest --runInBand -t \"(flow|fluxo|flows|opções)\"",
     "validate:flows": "npm run test:flows",
     "test:ci": "jest --runInBand --coverage",
-    "validate": "npm run validate:answers && npm run validate:flows"
+    "validate": "npm run lint && npm run validate:answers && npm run validate:flows"
   },
   "keywords": [],
   "author": "Bruno M Noronha",
@@ -27,7 +29,13 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
+    "@typescript-eslint/eslint-plugin": "^8.44.1",
+    "@typescript-eslint/parser": "^8.44.1",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",
+    "prettier": "^3.6.2",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"


### PR DESCRIPTION
## Summary
- add ESLint and Prettier dev dependencies alongside lint/format npm scripts
- configure a project-aware ESLint setup with TypeScript-aware overrides and Prettier integration
- add shared Prettier preferences and lint ignore rules for build artifacts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8ebaec2888330a58d51220a156784