### PR TITLE
Improve WhatsApp client logging configuration

### DIFF
--- a/src/infrastructure/logging/createConsoleLikeLogger.ts
+++ b/src/infrastructure/logging/createConsoleLikeLogger.ts
@@ -19,6 +19,7 @@ export interface ConsoleLikeLogger {
   warn(message?: unknown, ...optionalParams: readonly unknown[]): void;
   error(message?: unknown, ...optionalParams: readonly unknown[]): void;
   debug?(message?: unknown, ...optionalParams: readonly unknown[]): void;
+  isLevelEnabled?(level: Level): boolean;
 }
 
 export interface ConsoleLikeLoggerOptions {
@@ -94,5 +95,8 @@ export function createConsoleLikeLogger(options: ConsoleLikeLoggerOptions = {}):
     warn: bind('warn'),
     error: bind('error'),
     debug: bind('debug'),
+    isLevelEnabled: (targetLevel: Level): boolean => {
+      return typeof logger.isLevelEnabled === 'function' ? logger.isLevelEnabled(targetLevel) : true;
+    },
   };
 }


### PR DESCRIPTION
## Summary
- expose `ConsoleLikeLogger.isLevelEnabled` in the Pino adapter
- allow the WhatsApp client builder to create/use console-like loggers with contextual access
- skip high-volume message logging when the configured level does not require it

## Testing
- npm run build *(fails: missing Jest and Pino type definitions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f3d71a5883309d29a81cd3a97063