### PR TITLE
Refine flow module registry typing

### DIFF
--- a/__tests__/flow-restart.test.ts
+++ b/__tests__/flow-restart.test.ts
@@ -3,6 +3,7 @@ import { FlowEngine } from '../src/flow-runtime/engine';
 import { createStore } from '../src/flow-runtime/stateStore';
 import {
   FlowSessionService,
+  type FlowAdvanceContext,
   type FlowAdvanceTexts,
   type FlowDefinition,
   type FlowModuleRegistry,
@@ -36,10 +37,10 @@ const catalogFlow: FlowDefinition = {
   },
 };
 
-const flowModules: FlowModuleRegistry = {
+const flowModules = {
   menu: { flow: menuFlow },
   catalog: { flow: catalogFlow },
-};
+} satisfies FlowModuleRegistry;
 
 const texts: FlowAdvanceTexts = {
   expiredFlowText: 'Sua sessão anterior foi encerrada.',
@@ -73,7 +74,7 @@ describe('FlowSessionService conversational behaviour', () => {
     resetDelay = jest.fn<void, [string]>();
   });
 
-  const buildContext = (input: string) => ({
+  const buildContext = (input: string): FlowAdvanceContext => ({
     chatId,
     input,
     flowEngine: engine,

--- a/src/application/container.ts
+++ b/src/application/container.ts
@@ -5,12 +5,7 @@ import { FlowEngine } from '../flow-runtime/engine';
 import { RateController } from '../flow-runtime/rateController';
 import { MessageRouter } from './messaging/MessageRouter';
 import type { MessageRouterDeps } from './messaging/MessageRouter';
-import {
-  FlowSessionService,
-  type FlowDefinition,
-  type FlowKey,
-  type FlowModuleRegistry,
-} from './flows/FlowSessionService';
+import { FlowSessionService, type FlowDefinition, type FlowKey } from './flows/FlowSessionService';
 import flows from '../flows';
 import {
   TEXT,
@@ -155,7 +150,7 @@ export function createApplicationContainer(options: ApplicationContainerOptions 
   });
 
   const flowSessionService = new FlowSessionService({
-    flowModules: flows as FlowModuleRegistry,
+    flowModules: flows,
     overrides: options.flows,
     menuFlowEnabled: config.menuFlowEnabled,
     promptWindowMs: config.flowPromptWindowMs,

--- a/src/flows/index.ts
+++ b/src/flows/index.ts
@@ -2,9 +2,9 @@ import type { FlowModuleRegistry } from '../application/flows/FlowSessionService
 import { catalogFlow } from './catalog';
 import { menuFlow } from './menu';
 
-export const flowRegistry: FlowModuleRegistry = {
+export const flowRegistry = {
   catalog: { flow: catalogFlow },
   menu: { flow: menuFlow },
-};
+} satisfies FlowModuleRegistry;
 
 export default flowRegistry;


### PR DESCRIPTION
## Summary
- tighten the flow module registry typing to require FlowModule wrappers and improve error reporting when a flow is missing
- update flow registries and tests to export { flow: definition } objects while preserving explicit context typing
- align the application container with the refined registry contract

## Testing
- npm run lint *(fails: existing prettier/@typescript-eslint findings in unrelated files)*
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d96fce5c288330b6dc449351dfa35d