### PR TITLE
Refactor flow prompts to use discriminated union

### DIFF
--- a/__tests__/flow-restart.test.ts
+++ b/__tests__/flow-restart.test.ts
@@ -24,14 +24,18 @@ const catalogFlow: FlowDefinition = {
   nodes: {
     'catalog:start': {
       id: 'catalog:start',
+      kind: 'text',
       prompt: 'Escolha uma categoria',
+      promptContent: 'Escolha uma categoria',
       options: [
         { id: 'produtos', text: 'Produtos', aliases: ['1'], next: 'catalog:produtos' },
       ],
     },
     'catalog:produtos': {
       id: 'catalog:produtos',
+      kind: 'text',
       prompt: 'Lista de produtos',
+      promptContent: 'Lista de produtos',
       terminal: true,
     },
   },

--- a/src/flows/catalog.ts
+++ b/src/flows/catalog.ts
@@ -6,7 +6,9 @@ export const catalogFlow: FlowDefinition = {
   nodes: {
     inicio: {
       id: 'inicio',
+      kind: 'text',
       prompt: `${TEXT.welcomeHeader}\n${TEXT.welcomeBody}`,
+      promptContent: `${TEXT.welcomeHeader}\n${TEXT.welcomeBody}`,
       options: [
         { id: 'consertos', text: 'Consertos', aliases: ['1'], next: 'consertos' },
         { id: 'produtos', text: 'Produtos', aliases: ['2'], next: 'produtos' },
@@ -15,7 +17,9 @@ export const catalogFlow: FlowDefinition = {
     },
     consertos: {
       id: 'consertos',
+      kind: 'text',
       prompt: 'Tipos de conserto:',
+      promptContent: 'Tipos de conserto:',
       options: [
         { id: 'sola', text: 'Troca de sola', aliases: ['1'], next: 'final' },
         { id: 'costura', text: 'Reparo de costura', aliases: ['2'], next: 'final' },
@@ -24,7 +28,9 @@ export const catalogFlow: FlowDefinition = {
     },
     produtos: {
       id: 'produtos',
+      kind: 'text',
       prompt: 'Produtos disponíveis:',
+      promptContent: 'Produtos disponíveis:',
       options: [
         { id: 'cadarco', text: 'Cadarços', aliases: ['1'], next: 'final' },
         { id: 'palmilha', text: 'Palmilhas', aliases: ['2'], next: 'final' },
@@ -33,12 +39,16 @@ export const catalogFlow: FlowDefinition = {
     },
     atendente: {
       id: 'atendente',
+      kind: 'text',
       prompt: 'Ok, conectando com um atendente...',
+      promptContent: 'Ok, conectando com um atendente...',
       terminal: true,
     },
     final: {
       id: 'final',
+      kind: 'text',
       prompt: 'Perfeito! Vamos seguir com essa opção. Algo mais?',
+      promptContent: 'Perfeito! Vamos seguir com essa opção. Algo mais?',
       terminal: true,
     },
   },

--- a/src/flows/menu.ts
+++ b/src/flows/menu.ts
@@ -6,8 +6,9 @@ export const menuFlow: FlowDefinition = {
   nodes: {
     inicio: {
       id: 'inicio',
+      kind: 'list',
       prompt: `${TEXT.welcomeHeader}\n${TEXT.welcomeBody}`,
-      template: INITIAL_MENU_TEMPLATE,
+      promptContent: INITIAL_MENU_TEMPLATE,
       options: [
         { id: 'orcamento', text: 'Solicitar orçamento', aliases: ['1'], next: 'orcamento' },
         { id: 'andamento', text: 'Verificar andamento da OS', aliases: ['2'], next: 'andamento' },
@@ -17,22 +18,30 @@ export const menuFlow: FlowDefinition = {
     },
     orcamento: {
       id: 'orcamento',
+      kind: 'text',
       prompt: TEXT.responses.orçamento,
+      promptContent: TEXT.responses.orçamento,
       terminal: true,
     },
     andamento: {
       id: 'andamento',
+      kind: 'text',
       prompt: TEXT.responses.andamento,
+      promptContent: TEXT.responses.andamento,
       terminal: true,
     },
     localizacao: {
       id: 'localizacao',
+      kind: 'text',
       prompt: TEXT.responses.localizacao,
+      promptContent: TEXT.responses.localizacao,
       terminal: true,
     },
     outras: {
       id: 'outras',
+      kind: 'text',
       prompt: TEXT.responses.outras,
+      promptContent: TEXT.responses.outras,
       terminal: true,
       lockOnComplete: true,
     },


### PR DESCRIPTION
## Summary
- introduce a discriminated prompt union in `FlowSessionService` with a formatter that builds either text or WhatsApp list messages
- update menu and catalog flow definitions to declare prompt kinds/payloads and drop the legacy template flag
- adjust flow restart tests to assert against the new node shape

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d973e9ea348330b36c3fa22474aeff