### PR TITLE
feat: improve fuzzy matching confirmation flow

### DIFF
--- a/__tests__/answers-and-flows.test.js
+++ b/__tests__/answers-and-flows.test.js
@@ -31,6 +31,7 @@ describe('answers | opções de respostas', () => {
     expect(matcher.match('2')?.option.id).toBe('2');               // id
     expect(matcher.match('go')?.option.id).toBe('1');              // alias
     expect(matcher.match('continuar')?.option.id).toBe('1');       // texto normalizado
+    expect(matcher.match('1')?.kind).toBe('exact');
     expect(matcher.match('1')?.matchedBy).toBe('id');
     expect(matcher.match('2')?.matchedBy).toBe('id');
     expect(matcher.match('3')).toBeNull();
@@ -44,6 +45,19 @@ describe('answers | opções de respostas', () => {
     const matcher = buildOptionMatcher(options);
     expect(matcher.match('1')?.option.id).toBe('a'); // índice 1
     expect(matcher.match('segunda')?.option.id).toBe('b'); // texto normalizado
+  });
+
+  test('matchOption sugere melhor correspondência com confiança', () => {
+    const options = [
+      { id: 'orcamento', text: 'Solicitar orçamento' },
+      { id: 'andamento', text: 'Verificar andamento da OS' }
+    ];
+    const matcher = buildOptionMatcher(options);
+    const result = matcher.matchOption('solicitar orcament', { minimumConfidence: 0.4 });
+    expect(result).not.toBeNull();
+    expect(result.kind).toBe('suggestion');
+    expect(result.option.id).toBe('orcamento');
+    expect(result.confidence).toBeGreaterThanOrEqual(0.4);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.4.5",
+    "fast-fuzzy": "^1.12.0",
     "pino": "^9.3.1",
     "qrcode-terminal": "^0.12.0",
     "whatsapp-web.js": "^1.34.1"

--- a/src/config/messages.ts
+++ b/src/config/messages.ts
@@ -110,5 +110,24 @@ export const FALLBACK_MENU_TEMPLATE: MenuTemplate = {
 export const LOCK_DURATION_MS = 15 * 60 * 1000;
 export const RESPONSE_BASE_DELAY_MS = 5_000;
 export const RESPONSE_DELAY_FACTOR = 1.5;
-export const FUZZY_SUGGESTION_THRESHOLD = 0.45;
-export const FUZZY_CONFIRMATION_THRESHOLD = 0.75;
+
+function readThresholdFromEnv(envKey: string, fallback: number): number {
+  const raw = process.env[envKey];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (Number.isNaN(parsed)) {
+    return fallback;
+  }
+  if (parsed < 0) {
+    return 0;
+  }
+  if (parsed > 1) {
+    return 1;
+  }
+  return parsed;
+}
+
+export const FUZZY_SUGGESTION_THRESHOLD = readThresholdFromEnv('FUZZY_SUGGESTION_THRESHOLD', 0.45);
+export const FUZZY_CONFIRMATION_THRESHOLD = readThresholdFromEnv('FUZZY_CONFIRMATION_THRESHOLD', 0.75);


### PR DESCRIPTION
## Summary
- add a strategy-based option matcher with fast-fuzzy suggestions and expose matchOption confidences
- add an awaiting-confirmation state to the recovery service so denials do not consume attempts
- make fuzzy thresholds configurable through env vars and extend tests for the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d97783972c8330b73a0253c2a08b1a