### PR TITLE
feat: auto-start menu when chat lacks session

### DIFF
--- a/src/application/messaging/MessageRouter.ts
+++ b/src/application/messaging/MessageRouter.ts
@@ -96,6 +96,20 @@ class FlowMessageHandler extends BaseMessageHandler {
       return true;
     }
 
+    const hasSession = await context.flowEngine.isActive(context.chatId);
+    if (!hasSession) {
+      const restarted = await context.flowSessionService.ensureInitialMenu({
+        chatId: context.chatId,
+        flowEngine: context.flowEngine,
+        sendSafe: context.sendSafe,
+        resetDelay: context.resetDelay,
+        flowUnavailableText: context.flowUnavailableText,
+      });
+      if (restarted) {
+        return true;
+      }
+    }
+
     return this.handleNext(context);
   }
 }


### PR DESCRIPTION
## Summary
- introduce a state-based controller in FlowSessionService so inactive chats trigger the initial menu before attempting to resume flows
- expose an ensureInitialMenu helper and use it from FlowMessageHandler to send the menu when no session is active, keeping throttled sendSafe usage centralized

## Testing
- `npm test -- --runInBand` *(fails: missing optional dependency fast-fuzzy types in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97c35ba20833098a6cf4eab6c4f62