### PR TITLE
Decorate sendSafe with response delay handling

### DIFF
--- a/src/application/messaging/MessageSender.ts
+++ b/src/application/messaging/MessageSender.ts
@@ -1,0 +1,47 @@
+import type { Client, MessageContent } from 'whatsapp-web.js';
+import { RateController } from '../../flow-runtime/rateController';
+import { ResponseDelayManager } from './ResponseDelayManager';
+
+export interface MessageSender {
+  send(chatId: string, content: MessageContent): Promise<unknown>;
+}
+
+export class ClientMessageSender implements MessageSender {
+  constructor(private readonly client: Client) {}
+
+  async send(chatId: string, content: MessageContent): Promise<unknown> {
+    return this.client.sendMessage(chatId, content);
+  }
+}
+
+export abstract class MessageSenderDecorator implements MessageSender {
+  protected constructor(protected readonly inner: MessageSender) {}
+
+  abstract send(chatId: string, content: MessageContent): Promise<unknown>;
+}
+
+export class RateLimitedMessageSender extends MessageSenderDecorator {
+  constructor(inner: MessageSender, private readonly rateController: RateController) {
+    super(inner);
+  }
+
+  async send(chatId: string, content: MessageContent): Promise<unknown> {
+    return this.rateController.withSend(chatId, () => this.inner.send(chatId, content));
+  }
+}
+
+export class DelayedMessageSender extends MessageSenderDecorator {
+  constructor(inner: MessageSender, private readonly delayManager: ResponseDelayManager) {
+    super(inner);
+  }
+
+  async send(chatId: string, content: MessageContent): Promise<unknown> {
+    const delay = this.delayManager.nextDelay(chatId);
+    if (delay > 0) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delay);
+      });
+    }
+    return this.inner.send(chatId, content);
+  }
+}


### PR DESCRIPTION
## Summary
- add message sender decorator hierarchy to compose client sending, response delays, and rate limiting
- update the application container to build the sendSafe pipeline using the decorator chain

## Testing
- npm test -- --runTestsByPath __tests__/flow-restart.test.ts *(fails: Cannot find module 'fast-fuzzy' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68d97dc1d85c83308e57f2f367942705