### PR TITLE
Normaliza EXIT_ON_SHUTDOWN e cobre container com testes

### DIFF
--- a/__tests__/container-config.test.ts
+++ b/__tests__/container-config.test.ts
@@ -1,0 +1,88 @@
+import type { ApplicationContainer } from '../src/application/container';
+
+type ContainerModule = typeof import('../src/application/container');
+
+interface SetupResult {
+  readonly createApplicationContainer: ContainerModule['createApplicationContainer'];
+  readonly createCommandRegistryMock: jest.Mock;
+}
+
+async function loadContainer(): Promise<SetupResult> {
+  jest.resetModules();
+
+  const createCommandRegistryMock: jest.Mock = jest.fn().mockReturnValue({ run: jest.fn() });
+
+  jest.doMock('../src/app/commandRegistry', () => ({
+    createCommandRegistry: createCommandRegistryMock,
+  }));
+
+  const module: ContainerModule = await import('../src/application/container');
+  return {
+    createApplicationContainer: module.createApplicationContainer,
+    createCommandRegistryMock,
+  };
+}
+
+function getShouldExitOnShutdown(mock: jest.Mock): boolean {
+  const firstCall: unknown[] | undefined = mock.mock.calls[0];
+  if (!firstCall) {
+    throw new Error('createCommandRegistry não foi chamado');
+  }
+  const args = firstCall[0] as { shouldExitOnShutdown: boolean };
+  return args.shouldExitOnShutdown;
+}
+
+describe('normalização de EXIT_ON_SHUTDOWN', () => {
+  const ORIGINAL_ENV: NodeJS.ProcessEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  test('valor ausente utiliza fallback padrão baseado em NODE_ENV', async () => {
+    delete process.env.EXIT_ON_SHUTDOWN;
+    process.env.NODE_ENV = 'test';
+
+    const { createApplicationContainer, createCommandRegistryMock } = await loadContainer();
+    const container: ApplicationContainer = createApplicationContainer();
+    void container.client;
+
+    expect(getShouldExitOnShutdown(createCommandRegistryMock)).toBe(false);
+  });
+
+  test('valor vazio ou whitespace é tratado como ausente', async () => {
+    process.env.EXIT_ON_SHUTDOWN = '  ';
+    process.env.NODE_ENV = 'production';
+
+    const { createApplicationContainer, createCommandRegistryMock } = await loadContainer();
+    const container: ApplicationContainer = createApplicationContainer();
+    void container.client;
+
+    expect(getShouldExitOnShutdown(createCommandRegistryMock)).toBe(true);
+  });
+
+  test('valor "0" desabilita a finalização do processo', async () => {
+    process.env.EXIT_ON_SHUTDOWN = '0';
+    process.env.NODE_ENV = 'production';
+
+    const { createApplicationContainer, createCommandRegistryMock } = await loadContainer();
+    const container: ApplicationContainer = createApplicationContainer();
+    void container.client;
+
+    expect(getShouldExitOnShutdown(createCommandRegistryMock)).toBe(false);
+  });
+
+  test('valor "1" força a finalização do processo', async () => {
+    process.env.EXIT_ON_SHUTDOWN = '1';
+    process.env.NODE_ENV = 'test';
+
+    const { createApplicationContainer, createCommandRegistryMock } = await loadContainer();
+    const container: ApplicationContainer = createApplicationContainer();
+    void container.client;
+
+    expect(getShouldExitOnShutdown(createCommandRegistryMock)).toBe(true);
+  });
+});

--- a/src/application/container.ts
+++ b/src/application/container.ts
@@ -79,16 +79,37 @@ interface ApplicationContainerOverrides {
 
 export interface ApplicationContainerOptions extends ApplicationContainerOverrides {}
 
+function normalizeBooleanEnv(value: string | null | undefined): boolean | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  const trimmedValue: string = value.trim();
+  if (trimmedValue === '') {
+    return undefined;
+  }
+
+  const lowerCasedValue: string = trimmedValue.toLowerCase();
+  if (lowerCasedValue === '1' || lowerCasedValue === 'true' || lowerCasedValue === 'yes') {
+    return true;
+  }
+
+  if (lowerCasedValue === '0' || lowerCasedValue === 'false' || lowerCasedValue === 'no') {
+    return false;
+  }
+
+  return undefined;
+}
+
 function createConfig(overrides: ApplicationContainerOverrides): ApplicationContainerConfig {
   const authDir = overrides.authDir ?? path.resolve(process.cwd(), process.env.WWEBJS_AUTH_DIR ?? '.wwebjs_auth');
   const ownerId = overrides.ownerId ?? process.env.OWNER_ID ?? '';
   const allowSelfAdmin = overrides.allowSelfAdmin ?? process.env.ALLOW_SELF_ADMIN === '1';
   const menuFlowEnabled = overrides.menuFlowEnabled ?? process.env.MENU_FLOW === '1';
   const flowPromptWindowMs = overrides.flowPromptWindowMs ?? Number(process.env.FLOW_PROMPT_WINDOW_MS ?? DEFAULT_FLOW_PROMPT_WINDOW_MS);
+  const normalizedExitOnShutdown: boolean | undefined = normalizeBooleanEnv(process.env.EXIT_ON_SHUTDOWN);
   const shouldExitOnShutdown = overrides.shouldExitOnShutdown
-    ?? (process.env.EXIT_ON_SHUTDOWN != null
-      ? process.env.EXIT_ON_SHUTDOWN === '1'
-      : process.env.NODE_ENV !== 'test');
+    ?? (normalizedExitOnShutdown ?? (process.env.NODE_ENV !== 'test'));
   const flowUnavailableText = overrides.flowUnavailableText ?? 'Fluxo indisponível no momento.';
   const shutdownNotice = overrides.shutdownNotice ?? 'Encerrando o bot com segurança…';
   const restartNotice = overrides.restartNotice ?? 'Reiniciando o bot…';


### PR DESCRIPTION
## Resumo
- adiciona utilitário para normalizar variáveis booleanas do ambiente no container da aplicação
- mantém o fallback padrão de desligamento quando EXIT_ON_SHUTDOWN está ausente ou vazio
- cria testes unitários garantindo os cenários ausente, vazio, "0" e "1"

## Testes
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9b6f7c97c833097c531e7897b0b95