### PR TITLE
Normalizar leitura de números de ambiente no container

### DIFF
--- a/__tests__/container-config.test.ts
+++ b/__tests__/container-config.test.ts
@@ -1,25 +1,118 @@
 import type { ApplicationContainer } from '../src/application/container';
+import { DEFAULT_FLOW_PROMPT_WINDOW_MS } from '../src/app/flowPromptTracker';
 
 type ContainerModule = typeof import('../src/application/container');
 
 interface SetupResult {
   readonly createApplicationContainer: ContainerModule['createApplicationContainer'];
   readonly createCommandRegistryMock: jest.Mock;
+  readonly flowSessionServiceMock: jest.Mock;
+  readonly rateControllerMock: jest.Mock;
+  readonly lifecycleManagerMock: jest.Mock;
 }
 
 async function loadContainer(): Promise<SetupResult> {
   jest.resetModules();
 
   const createCommandRegistryMock: jest.Mock = jest.fn().mockReturnValue({ run: jest.fn() });
+  const flowSessionServiceMock: jest.Mock = jest.fn().mockImplementation(() => ({
+    getFlowDefinition: jest.fn(),
+    sendPrompt: jest.fn(),
+    clearPrompt: jest.fn(),
+  }));
+  const flowEngineInstance = {};
+  const flowEngineMock: jest.Mock = jest.fn().mockReturnValue(flowEngineInstance);
+  const rateControllerMock: jest.Mock = jest.fn().mockImplementation((config: unknown) => ({
+    start: jest.fn(),
+    stop: jest.fn(),
+    withSend: jest.fn((_: string, fn: () => Promise<unknown>) => fn()),
+    config,
+  }));
+  const lifecycleManagerMock: jest.Mock = jest.fn().mockImplementation((options: unknown) => ({
+    start: jest.fn(),
+    stop: jest.fn(),
+    restart: jest.fn(),
+    options,
+  }));
+  const fakeClient = {
+    on: jest.fn(),
+    initialize: jest.fn(),
+    destroy: jest.fn(),
+  };
+  const fakeRate = {
+    start: jest.fn(),
+    stop: jest.fn(),
+    withSend: jest.fn(async (_: string, fn: () => Promise<unknown>) => fn()),
+  };
+  const fakeLogger = {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  const fakeApp = {
+    client: fakeClient,
+    rate: fakeRate,
+    flowEngine: flowEngineInstance,
+    start: jest.fn(),
+    stop: jest.fn(),
+  };
+  type HandlerFactory = (ctx: {
+    client: typeof fakeClient;
+    rate: typeof fakeRate;
+    flowEngine: typeof flowEngineInstance;
+    logger: typeof fakeLogger;
+  }) => unknown;
+  let storedHandlerFactory: HandlerFactory | undefined;
+  const builderInstance = {
+    withHandlers: jest.fn().mockImplementation((factory: HandlerFactory) => {
+      storedHandlerFactory = factory;
+      return builderInstance;
+    }),
+    build: jest.fn().mockImplementation(() => {
+      if (storedHandlerFactory) {
+        storedHandlerFactory({
+          client: fakeClient,
+          rate: fakeRate,
+          flowEngine: flowEngineInstance,
+          logger: fakeLogger,
+        });
+      }
+      return fakeApp;
+    }),
+  };
+  const createWhatsAppClientBuilderMock: jest.Mock = jest.fn().mockReturnValue(builderInstance);
 
   jest.doMock('../src/app/commandRegistry', () => ({
     createCommandRegistry: createCommandRegistryMock,
+  }));
+
+  jest.doMock('../src/application/flows/FlowSessionService', () => ({
+    FlowSessionService: flowSessionServiceMock,
+  }));
+
+  jest.doMock('../src/flow-runtime/engine', () => ({
+    FlowEngine: flowEngineMock,
+  }));
+
+  jest.doMock('../src/flow-runtime/rateController', () => ({
+    RateController: rateControllerMock,
+  }));
+
+  jest.doMock('../src/infrastructure/whatsapp/LifecycleManager', () => ({
+    LifecycleManager: lifecycleManagerMock,
+  }));
+
+  jest.doMock('../src/infrastructure/whatsapp/ClientFactory', () => ({
+    createWhatsAppClientBuilder: createWhatsAppClientBuilderMock,
   }));
 
   const module: ContainerModule = await import('../src/application/container');
   return {
     createApplicationContainer: module.createApplicationContainer,
     createCommandRegistryMock,
+    flowSessionServiceMock,
+    rateControllerMock,
+    lifecycleManagerMock,
   };
 }
 
@@ -84,5 +177,82 @@ describe('normalização de EXIT_ON_SHUTDOWN', () => {
     void container.client;
 
     expect(getShouldExitOnShutdown(createCommandRegistryMock)).toBe(true);
+  });
+});
+
+describe('normalização de números de ambiente', () => {
+  const ORIGINAL_ENV: NodeJS.ProcessEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  test('FLOW_PROMPT_WINDOW_MS inválido recorre ao fallback padrão', async (): Promise<void> => {
+    process.env.FLOW_PROMPT_WINDOW_MS = 'não-numérico';
+
+    const { createApplicationContainer, flowSessionServiceMock } = await loadContainer();
+    void createApplicationContainer();
+
+    const firstCall = flowSessionServiceMock.mock.calls[0];
+    const config = firstCall?.[0] as { promptWindowMs: number } | undefined;
+
+    expect(config?.promptWindowMs).toBe(DEFAULT_FLOW_PROMPT_WINDOW_MS);
+  });
+
+  test('FLOW_PROMPT_WINDOW_MS válido é convertido corretamente', async (): Promise<void> => {
+    process.env.FLOW_PROMPT_WINDOW_MS = ' 42000 ';
+
+    const { createApplicationContainer, flowSessionServiceMock } = await loadContainer();
+    void createApplicationContainer();
+
+    const firstCall = flowSessionServiceMock.mock.calls[0];
+    const config = firstCall?.[0] as { promptWindowMs: number } | undefined;
+
+    expect(config?.promptWindowMs).toBe(42000);
+  });
+
+  test('limites de rate usam fallback quando valores não são finitos', async (): Promise<void> => {
+    process.env.RATE_PER_CHAT_COOLDOWN_MS = 'NaN';
+    process.env.THROTTLE_GLOBAL_MAX = 'Infinity';
+    process.env.THROTTLE_GLOBAL_INTERVAL_MS = 'texto';
+
+    const { createApplicationContainer, rateControllerMock } = await loadContainer();
+    void createApplicationContainer();
+
+    const firstCall = rateControllerMock.mock.calls[0];
+    const config = firstCall?.[0] as {
+      perChatCooldownMs: number;
+      globalMaxPerInterval: number;
+      globalIntervalMs: number;
+    } | undefined;
+
+    expect(config?.perChatCooldownMs).toBe(1200);
+    expect(config?.globalMaxPerInterval).toBe(12);
+    expect(config?.globalIntervalMs).toBe(1000);
+  });
+
+  test('parâmetros de remoção de auth e reconexão respeitam fallback', async (): Promise<void> => {
+    process.env.AUTH_RM_RETRIES = '';
+    process.env.AUTH_RM_BASE_DELAY_MS = '   ';
+    process.env.AUTH_RM_MAX_DELAY_MS = 'null';
+    delete process.env.RECONNECT_MAX_BACKOFF_MS;
+    process.env.RECONNECT_BASE_BACKOFF_MS = 'NaN';
+    process.env.RECONNECT_BACKOFF_FACTOR = '0x10';
+
+    const { createApplicationContainer, lifecycleManagerMock } = await loadContainer();
+    const container: ApplicationContainer = createApplicationContainer();
+    void container.client;
+
+    const firstCall = lifecycleManagerMock.mock.calls[0];
+    const options = firstCall?.[0] as {
+      authRemoval: { retries: number; baseDelay: number; maxDelay: number };
+      reconnect: { maxBackoffMs: number; baseBackoffMs: number; factor: number };
+    } | undefined;
+
+    expect(options?.authRemoval).toEqual({ retries: 10, baseDelay: 200, maxDelay: 2000 });
+    expect(options?.reconnect).toEqual({ maxBackoffMs: 30000, baseBackoffMs: 1000, factor: 16 });
   });
 });

--- a/src/application/container.ts
+++ b/src/application/container.ts
@@ -101,12 +101,31 @@ function normalizeBooleanEnv(value: string | null | undefined): boolean | undefi
   return undefined;
 }
 
+function normalizeNumberEnv(value: string | undefined, fallback: number): number {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmedValue: string = value.trim();
+  if (trimmedValue === '') {
+    return fallback;
+  }
+
+  const parsedValue: number = Number(trimmedValue);
+  if (!Number.isFinite(parsedValue)) {
+    return fallback;
+  }
+
+  return parsedValue;
+}
+
 function createConfig(overrides: ApplicationContainerOverrides): ApplicationContainerConfig {
   const authDir = overrides.authDir ?? path.resolve(process.cwd(), process.env.WWEBJS_AUTH_DIR ?? '.wwebjs_auth');
   const ownerId = overrides.ownerId ?? process.env.OWNER_ID ?? '';
   const allowSelfAdmin = overrides.allowSelfAdmin ?? process.env.ALLOW_SELF_ADMIN === '1';
   const menuFlowEnabled = overrides.menuFlowEnabled ?? process.env.MENU_FLOW === '1';
-  const flowPromptWindowMs = overrides.flowPromptWindowMs ?? Number(process.env.FLOW_PROMPT_WINDOW_MS ?? DEFAULT_FLOW_PROMPT_WINDOW_MS);
+  const flowPromptWindowMs = overrides.flowPromptWindowMs
+    ?? normalizeNumberEnv(process.env.FLOW_PROMPT_WINDOW_MS, DEFAULT_FLOW_PROMPT_WINDOW_MS);
   const normalizedExitOnShutdown: boolean | undefined = normalizeBooleanEnv(process.env.EXIT_ON_SHUTDOWN);
   const shouldExitOnShutdown = overrides.shouldExitOnShutdown
     ?? (normalizedExitOnShutdown ?? (process.env.NODE_ENV !== 'test'));
@@ -118,19 +137,28 @@ function createConfig(overrides: ApplicationContainerOverrides): ApplicationCont
   const invalidOptionText = overrides.invalidOptionText ?? 'Não entendi. Por favor, escolha uma das opções listadas.';
   const genericFlowErrorText = overrides.genericFlowErrorText ?? 'Ocorreu um erro no fluxo. Encerrando.';
   const rateLimits: RateLimitsConfig = {
-    perChatCooldownMs: overrides.rateLimits?.perChatCooldownMs ?? Number(process.env.RATE_PER_CHAT_COOLDOWN_MS ?? 1200),
-    globalMaxPerInterval: overrides.rateLimits?.globalMaxPerInterval ?? Number(process.env.THROTTLE_GLOBAL_MAX ?? 12),
-    globalIntervalMs: overrides.rateLimits?.globalIntervalMs ?? Number(process.env.THROTTLE_GLOBAL_INTERVAL_MS ?? 1000),
+    perChatCooldownMs: overrides.rateLimits?.perChatCooldownMs
+      ?? normalizeNumberEnv(process.env.RATE_PER_CHAT_COOLDOWN_MS, 1200),
+    globalMaxPerInterval: overrides.rateLimits?.globalMaxPerInterval
+      ?? normalizeNumberEnv(process.env.THROTTLE_GLOBAL_MAX, 12),
+    globalIntervalMs: overrides.rateLimits?.globalIntervalMs
+      ?? normalizeNumberEnv(process.env.THROTTLE_GLOBAL_INTERVAL_MS, 1000),
   };
   const authRemoval: AuthRemovalConfig = {
-    retries: overrides.authRemoval?.retries ?? Number(process.env.AUTH_RM_RETRIES ?? 10),
-    baseDelay: overrides.authRemoval?.baseDelay ?? Number(process.env.AUTH_RM_BASE_DELAY_MS ?? 200),
-    maxDelay: overrides.authRemoval?.maxDelay ?? Number(process.env.AUTH_RM_MAX_DELAY_MS ?? 2000),
+    retries: overrides.authRemoval?.retries
+      ?? normalizeNumberEnv(process.env.AUTH_RM_RETRIES, 10),
+    baseDelay: overrides.authRemoval?.baseDelay
+      ?? normalizeNumberEnv(process.env.AUTH_RM_BASE_DELAY_MS, 200),
+    maxDelay: overrides.authRemoval?.maxDelay
+      ?? normalizeNumberEnv(process.env.AUTH_RM_MAX_DELAY_MS, 2000),
   };
   const reconnect: ReconnectConfig = {
-    maxBackoffMs: overrides.reconnect?.maxBackoffMs ?? Number(process.env.RECONNECT_MAX_BACKOFF_MS ?? 30000),
-    baseBackoffMs: overrides.reconnect?.baseBackoffMs ?? Number(process.env.RECONNECT_BASE_BACKOFF_MS ?? 1000),
-    factor: overrides.reconnect?.factor ?? Number(process.env.RECONNECT_BACKOFF_FACTOR ?? 2),
+    maxBackoffMs: overrides.reconnect?.maxBackoffMs
+      ?? normalizeNumberEnv(process.env.RECONNECT_MAX_BACKOFF_MS, 30000),
+    baseBackoffMs: overrides.reconnect?.baseBackoffMs
+      ?? normalizeNumberEnv(process.env.RECONNECT_BASE_BACKOFF_MS, 1000),
+    factor: overrides.reconnect?.factor
+      ?? normalizeNumberEnv(process.env.RECONNECT_BACKOFF_FACTOR, 2),
   };
   return {
     authDir,


### PR DESCRIPTION
## Resumo
- adiciona helper para normalizar números lidos das variáveis de ambiente no container
- reutiliza o helper para janela de prompt, limites de rate, remoção de auth e parâmetros de reconexão
- amplia os testes de configuração cobrindo cenários válidos e inválidos ao carregar números

## Testes
- npm test -- container-config

------
https://chatgpt.com/codex/tasks/task_e_68d9b8c9eda88330aa2d337eb9cfa7d7