### PR TITLE
Adiciona script de cobertura e nota para uso em CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Execute com cobertura:
 npm run test:coverage
 ```
 
+> 💡 Para pipelines de integração contínua, utilize `npm run test:ci`, que compartilha a mesma configuração de cobertura e facilita a integração com provedores de CI sem ajustes adicionais.
+
 ### Padrões de teste
 
 - Mocks manuais para `whatsapp-web.js` e `qrcode-terminal`

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "validate:answers": "npm run test:answers",
     "test:flows": "jest --runInBand -t \"(flow|fluxo|flows|opções)\"",
     "validate:flows": "npm run test:flows",
+    "test:coverage": "jest --runInBand --coverage",
     "test:ci": "jest --runInBand --coverage",
     "validate": "npm run lint && npm run validate:answers && npm run validate:flows"
   },


### PR DESCRIPTION
## Resumo
- adiciona o script `test:coverage` para alinhar o comando de cobertura documentado com o que existe no projeto
- documenta no README o uso de `npm run test:ci` em pipelines de integração contínua

## Testes
- não foram executados testes (mudanças de configuração/documentação)


------
https://chatgpt.com/codex/tasks/task_e_68d9bb2d6c7c83308c813741f536fc20